### PR TITLE
fix(utils): 修复标签页新窗口打开路由404问题和反馈表单异步处理

### DIFF
--- a/src/common/utils/core/browser/url.ts
+++ b/src/common/utils/core/browser/url.ts
@@ -6,10 +6,10 @@ export function getUrlParams(): URLSearchParams {
 }
 
 /**
- * 新窗口打开URL。
+ * 新窗口打开 URL
  *
- * @param url - 需要打开的网址。
- * @param options - 打开窗口的选项。
+ * @param url - 需要打开的网址
+ * @param options - 打开窗口的选项
  */
 export function openWindow(
   url: string,
@@ -32,7 +32,7 @@ export function openWindow(
 /**
  * 在新窗口中打开路由
  */
-export function openRouteInNewWindow(path: string) {
+export function openPathInNewWindow(path: string) {
   const { hash, origin } = location;
   const fullPath = path.startsWith("/") ? path : `/${path}`;
   const url = `${origin}${hash ? "/#" : ""}${fullPath}`;

--- a/src/components/pro/page/src/feedback-form.vue
+++ b/src/components/pro/page/src/feedback-form.vue
@@ -151,7 +151,7 @@ const handleDoAdd = <T extends Recordable = any>(data: T) => {
       const filterParams = [...(apiFilterKeys || []), ...(addFilterKeys || [])];
       filterParams.forEach(item => delete data[item]);
 
-      const result = onAdd?.(data);
+      const result = await onAdd?.(data);
       // 返回 false 则继续往下执行
       if (result !== false) return;
 
@@ -246,7 +246,7 @@ const handleRemove = async <T extends Recordable = any>(row: T, fallback: (resul
   const filterParams = [...(apiFilterKeys || []), ...(removeFilterKeys || [])];
   filterParams.forEach(item => delete data[item]);
 
-  const result = onRemove?.(data);
+  const result = await onRemove?.(data);
   // 返回 false 则继续往下执行
   if (result !== false) return;
 
@@ -295,7 +295,7 @@ const handleRemoveBatch = async (selectedListIds: string[], selectedList: any, f
       afterConfirm,
     } = props;
 
-    const result = onRemoveBatch?.(data);
+    const result = await onRemoveBatch?.(data);
     // 返回 false 则继续往下执行
     if (result !== false) return;
 

--- a/src/components/pro/page/src/index.vue
+++ b/src/components/pro/page/src/index.vue
@@ -100,7 +100,7 @@ const proTableProps = computed(() => {
         show: feedbackFormProps?.removeApi ? true : !!feedbackFormProps?.useRemove,
         el: "el-link",
         icon: Delete,
-        onClick: ({ row }) => feedbackFormInstance.value?.clickRemove(row),
+        onClick: ({ row }) => feedbackFormInstance.value?.clickRemove?.(row),
         onConfirm: ({ row }) => feedbackFormInstance.value?.handleRemove(row),
       }
     );

--- a/src/components/pro/page/src/types.ts
+++ b/src/components/pro/page/src/types.ts
@@ -207,19 +207,19 @@ export interface FeedbackFormProps<T extends Recordable = any> {
   /**
    * 新增点击保存按钮回调，将自定义新增逻辑，覆盖 addApi 逻辑，当两者同时存在时，onAdd 优先级高，返回 false 代表继续执行 addApi
    */
-  onAdd?: (model: T) => undefined | false;
+  onAdd?: (model: T) => undefined | false | Promise<undefined | false>;
   /**
    * 编辑点击保存按钮回调，将自定义新增逻辑，覆盖 editApi 逻辑，当两者同时存在时，onEdit 优先级高，返回 false 代表继续执行 editApi
    */
-  onEdit?: (model: T) => undefined | false;
+  onEdit?: (model: T) => undefined | false | Promise<undefined | false>;
   /**
    * 删除点击保存按钮回调，将自定义新增逻辑，覆盖 removeApi 逻辑，当两者同时存在时，onRemove 优先级高，返回 false 代表继续执行 removeApi
    */
-  onRemove?: (model: T) => undefined | false;
+  onRemove?: (model: T) => undefined | false | Promise<undefined | false>;
   /**
    * 批量删除点击保存按钮回调，将自定义新增逻辑，覆盖 removeBatchApi 逻辑，当两者同时存在时，onRemoveBatch 优先级高，返回 false 代表继续执行 removeBatchApi
    */
-  onRemoveBatch?: (model: T) => undefined | false;
+  onRemoveBatch?: (model: T) => undefined | false | Promise<undefined | false>;
   /**
    * add、edit、remove、removeBatch 任意操作完成后的回调
    */

--- a/src/layout/components/tab-nav/components/more-button/index.vue
+++ b/src/layout/components/tab-nav/components/more-button/index.vue
@@ -16,7 +16,6 @@ import {
   Lock,
   Unlock,
 } from "@element-plus/icons-vue";
-import { openRouteInNewWindow } from "@/common/utils";
 import { useSettingStore } from "@/pinia";
 import { useTabNav } from "../../use-tab-nav";
 
@@ -34,6 +33,7 @@ const {
   closeRightTab,
   closeOthersTabs,
   closeAllTabs,
+  openRouteInNewWindow,
 } = useTabNav();
 
 const settingStore = useSettingStore();

--- a/src/layout/components/tab-nav/components/right-menu/index.vue
+++ b/src/layout/components/tab-nav/components/right-menu/index.vue
@@ -16,7 +16,6 @@ import {
   Lock,
   Unlock,
 } from "@element-plus/icons-vue";
-import { openRouteInNewWindow } from "@/common/utils";
 import { useNamespace } from "@/composables";
 import { useSettingStore } from "@/pinia";
 import { useTabNav } from "../../use-tab-nav";
@@ -30,6 +29,7 @@ const {
   tabNavList,
   refreshSelectedTab,
   toggleFixed,
+  openRouteInNewWindow,
   closeTab,
   closeLeftTab,
   closeRightTab,

--- a/src/layout/components/tab-nav/tab-nav-classic/index.vue
+++ b/src/layout/components/tab-nav/tab-nav-classic/index.vue
@@ -4,7 +4,7 @@ import { ref, onMounted, watch, nextTick, useTemplateRef } from "vue";
 import { useRoute } from "vue-router";
 import { ElButton } from "element-plus";
 import { Close, ArrowLeft, ArrowRight } from "@element-plus/icons-vue";
-import { isString, openRouteInNewWindow } from "@/common/utils";
+import { isString } from "@/common/utils";
 import { useNamespace, useCommon } from "@/composables";
 import { useSettingStore } from "@/pinia";
 import { useTabNav } from "../use-tab-nav";
@@ -43,6 +43,7 @@ const {
   tabsDragSort,
   initAffixTabs,
   addTabByRoute,
+  openRouteInNewWindow,
   openRightMenu,
   closeTab,
 } = useTabNav();

--- a/src/layout/components/tab-nav/tab-nav-element/index.vue
+++ b/src/layout/components/tab-nav/tab-nav-element/index.vue
@@ -4,7 +4,7 @@ import type { TabProps } from "@/pinia";
 import { onMounted, watch, useTemplateRef } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { ElTabs, ElTabPane } from "element-plus";
-import { addUnit, removeUnit, isString, openRouteInNewWindow } from "@/common/utils";
+import { addUnit, removeUnit, isString } from "@/common/utils";
 import { useCommon, useNamespace } from "@/composables";
 import { useSettingStore } from "@/pinia";
 import { useTabNav } from "../use-tab-nav";
@@ -35,6 +35,7 @@ const {
   initAffixTabs,
   addTabByRoute,
   closeTab,
+  openRouteInNewWindow,
   openRightMenu,
 } = useTabNav();
 

--- a/src/layout/components/tab-nav/use-tab-nav.ts
+++ b/src/layout/components/tab-nav/use-tab-nav.ts
@@ -4,7 +4,7 @@ import { ref, reactive, computed } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { storeToRefs } from "pinia";
 import Sortable from "sortablejs";
-import { getUrlParams, isFunction } from "@/common/utils";
+import { getUrlParams, isFunction, openWindow, openPathInNewWindow } from "@/common/utils";
 import { serviceConfig, HOME_URL } from "@/common/config";
 import { useCommon, useMittBus } from "@/composables";
 import beforeClose from "@/router/before-close";
@@ -173,6 +173,19 @@ export const useTabNav = () => {
     layoutStore.addTab(tab);
 
     if (route.name) route.meta.isKeepAlive && layoutStore.addKeepAliveName(route.name as string);
+  };
+
+  /**
+   * 在新窗口中打开路由
+   */
+  const openRouteInNewWindow = (path: string) => {
+    try {
+      const { href } = router.resolve({ path });
+      openWindow(href, { target: "_blank" });
+    } catch {
+      // 根据 name 找不到路由，则走浏览器地址跳转
+      openPathInNewWindow(path);
+    }
   };
 
   /**
@@ -351,6 +364,7 @@ export const useTabNav = () => {
     addTabByRoute,
     toggleFixed,
     getRouteFullPath,
+    openRouteInNewWindow,
     openRightMenu,
     initContextMenu,
     closeTab,


### PR DESCRIPTION
- 修复 openWindow 函数的 JSDoc 注释格式
- 将 openRouteInNewWindow 重命名为 openPathInNewWindow 并移动到 useTabNav 钩子中
- 更新反馈表单中的 onAdd、onEdit、onRemove 和 onRemoveBatch 类型定义以支持 Promise
- 修改反馈表单中的异步处理逻辑，添加 await 关键字
- 调整更多按钮和右键菜单组件中的导入和使用方式
- 更新自动导入类型声明文件格式